### PR TITLE
Fix test imports and CSV export bug

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,6 +1,7 @@
 import base64
 import requests
 import logging
+import csv
 from io import BytesIO, StringIO
 from flask import Blueprint, render_template, session, request, redirect, url_for, jsonify, Response, flash
 from mutagen.mp3 import MP3

--- a/app/streamusic/__init__.py
+++ b/app/streamusic/__init__.py
@@ -1,0 +1,6 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+from app import create_app
+
+app = create_app()


### PR DESCRIPTION
## Summary
- expose a streamusic module so tests can access the Flask app
- add missing `csv` import in the export route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_6842f0f088c48332bef05cb21926b692