### PR TITLE
Fix env var name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Create a .env file in the root directory of the project with the following conte
 
 **REDIRECT_URI=http://localhost:5000/callback**
 
-**SECRET_KEY=your_flask_secret_key**
+**FLASK_SECRET_KEY=your_flask_secret_key**
 
 **DATABASE_URL=sqlite:///instance/app.db**
 


### PR DESCRIPTION
## Summary
- document `FLASK_SECRET_KEY` instead of outdated `SECRET_KEY` in sample `.env`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamusic')*

------
https://chatgpt.com/codex/tasks/task_e_6842f315c194833284395e3f6ef9eed1