### PR TITLE
Fix app name reference

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -6,7 +6,7 @@
     <img class="home-logo" src="/static/logo.png" alt="StreaMusic Logo">
     <h2 class="home-title">Welcome to StreaMusic</h2>
     <p class="home-desc">
-      StreamMusic is a OneDrive MP3 Streamer that lets you browse your OneDrive for MP3 files and stream your favorite tunes seamlessly from the cloud.
+      StreaMusic is a OneDrive MP3 Streamer that lets you browse your OneDrive for MP3 files and stream your favorite tunes seamlessly from the cloud.
     </p>
     <div class="button-group">
       {% if session.access_token %}


### PR DESCRIPTION
## Summary
- fix the StreaMusic name in the index page paragraph

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamusic')*

------
https://chatgpt.com/codex/tasks/task_e_6842f30397d08332aaad68ff21782b58