### PR TITLE
Remove duplicate queue event listener

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -33,9 +33,6 @@ document.addEventListener("DOMContentLoaded", function() {
     queueContainer.addEventListener("click", function(e) {
       e.stopPropagation();
     });
-    queueContainer.addEventListener("click", function(e) {
-      e.stopPropagation();
-    });
   }
 });
 document.addEventListener("click", function(e) {


### PR DESCRIPTION
## Summary
- deduplicate click listener for `queue-container` in `app.js`

## Testing
- `FLASK_SECRET_KEY=dummy CLIENT_ID=x CLIENT_SECRET=y REDIRECT_URI=http://localhost pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e2bad2c48332aa190904146b85c3