### PR TITLE
Fix slider thumb alignment in webkit and Firefox

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -490,6 +490,7 @@ main.queue-active { margin-right: 250px; }
   border: none;
   -webkit-appearance: none;
   appearance: none;
+  margin-top: -3px;
 }
 #progress-bar::-webkit-slider-runnable-track {
   background: transparent;
@@ -549,6 +550,7 @@ main.queue-active { margin-right: 250px; }
   background: #1db954;
   cursor: pointer;
   border: none;
+  margin-top: -3px;
 }
 #volume-slider::-moz-range-track {
   background: transparent;


### PR DESCRIPTION
## Summary
- vertically center seek and volume sliders with `margin-top`
- add `margin-top` for Firefox volume slider thumb

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487463a6e48332b46a1a30c52b2ab9