### PR TITLE
Limit queue history to last 3 songs

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -197,6 +197,14 @@ function clearQueue() {
   }
 }
 
+function trimQueue() {
+  if (currentIndex > 3) {
+    const removeCount = currentIndex - 3;
+    songQueue.splice(0, removeCount);
+    currentIndex -= removeCount;
+  }
+}
+
 function updateQueueUI() {
   const queueList = document.getElementById("queue-list");
   if (!queueList) return;
@@ -298,6 +306,7 @@ function showMetadata(fileId, signal) {
 }
 
 function playCurrentSong() {
+  trimQueue();
   if (currentIndex >= songQueue.length) {
     loadNextFromFileList();
     return;


### PR DESCRIPTION
## Summary
- add `trimQueue` helper to drop songs older than three
- call `trimQueue` at start of `playCurrentSong`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684960f76bd48332b2d05f6d42ee58f3