### PR TITLE
Integrate seek bar into navbar

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -32,7 +32,7 @@ body.files-bg .background {
   align-items: center;
   justify-content: space-between;
   background: #1f1f1f;
-  padding: 10px 30px;
+  padding: 14px 30px 10px;
   position: relative;
   height: 70px;
   box-shadow: 0 2px 5px rgba(0,0,0,0.2);
@@ -468,10 +468,13 @@ main.queue-active { margin-right: 250px; }
 }
 #shuffleBtn i, #repeatBtn i { color: #fff !important; }
 #progress-bar {
-  width: 120px;
-  height: 6px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
   border: none;
-  border-radius: 10px;
+  border-radius: 0;
   background: linear-gradient(
     to right,
     #1db954 0%, #1db954 var(--played, 0%),
@@ -480,7 +483,8 @@ main.queue-active { margin-right: 250px; }
   -webkit-appearance: none;
   appearance: none;
   outline: none;
-  margin: 0 8px;
+  margin: 0;
+  z-index: 150;
 }
 #progress-bar::-webkit-slider-thumb, #volume-slider::-webkit-slider-thumb {
   width: 12px; height: 12px;

--- a/app/templates/files.html
+++ b/app/templates/files.html
@@ -6,6 +6,7 @@
   <!-- NAVBAR WITH LOGO, CENTERED TITLE, QUEUE, HAMBURGER -->
   <header>
     <nav class="navbar">
+      <input type="range" id="progress-bar" value="0" min="0" max="100" step="1" class="nav-progress" />
       <div class="navbar-left">
         <a href="{{ url_for('main.home') }}">
           <img src="/static/logo.png" alt="StreaMusic Logo" class="navbar-logo">
@@ -106,7 +107,6 @@
       <button class="btn" id="playPauseBtn" onclick="togglePlayPause()"><i class="fas fa-play"></i></button>
       <button class="btn" onclick="nextSong()"><i class="fas fa-step-forward"></i></button>
       <span id="current-time">0:00</span>
-      <input type="range" id="progress-bar" value="0" min="0" max="100" step="1" />
       <span id="duration">0:00</span>
       <i id="volume-icon" class="fas fa-volume-up"></i>
       <input type="range" id="volume-slider" min="0" max="100" step="1" value="50">


### PR DESCRIPTION
## Summary
- move playback progress bar from player controls into the navbar
- style navbar padding to offset the new seek bar
- adjust progress bar styles for full width placement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498324a1a4833283456c6ebb287fd6