### PR TITLE
Update player display

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -291,11 +291,13 @@ function showMetadata(fileId, signal) {
         window.location.href = "/";
         return;
       }
-      document.getElementById("metadata-album").innerText = `Album: ${data.album || "Unknown"}`;
-      const durationText = data.duration ? formatDuration(data.duration) : "Unknown";
-      document.getElementById("metadata-duration").innerText = `Duration: ${durationText}`;
       const albumArtwork = document.getElementById("album-artwork");
-      albumArtwork.src = (data.album_art && data.album_art.trim() !== "") ? data.album_art : "";
+      if (data.album_art && data.album_art.trim() !== "") {
+        albumArtwork.src = data.album_art;
+      } else {
+        albumArtwork.src = "";
+      }
+      // album and duration information is no longer displayed in the UI
     })
     .catch(err => {
       if (err.name === "AbortError") {

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -294,16 +294,12 @@ body.files-bg .background {
 }
 .file-item .file-title {
   display: block;
-  font-weight: 600;
-  font-size: 1.15rem;
+  font-weight: 700;
+  font-size: 1.3rem;
 }
 .file-item .artist-album {
   display: block;
   font-size: 0.9rem;
-}
-.file-item .artist-album {
-  display: block;
-  font-size: 0.8rem;
   color: #ccc;
 }
 .file-item .actions {
@@ -440,12 +436,6 @@ main.queue-active { margin-right: 250px; }
   transition: transform 0.3s;
 }
 .metadata-panel img:hover { transform: scale(1.5); }
-.metadata-text {
-  font-size: 0.8rem;
-  line-height: 1.2;
-  color: #fff;
-  white-space: nowrap;
-}
 #now-playing {
   flex-grow: 1;
   text-align: center;

--- a/app/templates/files.html
+++ b/app/templates/files.html
@@ -90,14 +90,10 @@
 
   <!-- MEDIA PLAYER BAR -->
   <div id="media-player-container">
-    <div class="metadata-panel">
-      <img id="album-artwork" src="" alt="Album Artwork">
-      <div class="metadata-text">
-        <p id="metadata-album">Album: Unknown</p>
-        <p id="metadata-duration">Duration: Unknown</p>
+      <div class="metadata-panel">
+        <img id="album-artwork" src="" alt="Album Artwork">
+        <button id="lyrics-button" class="btn" onclick="openLyrics()">Lyrics</button>
       </div>
-      <button id="lyrics-button" class="btn" onclick="openLyrics()">Lyrics</button>
-    </div>
     <p id="now-playing"></p>
     <audio id="audio-player" preload="none" style="display:none;">
       <source id="audio-source" src="" type="audio/mp3">


### PR DESCRIPTION
## Summary
- hide album and duration info from the player panel
- style file titles with bold header text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e1ee6ee08332811794d189c867d4