### PR TITLE
Adjust queue and lyrics buttons

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -436,6 +436,13 @@ main.queue-active { margin-right: 250px; }
   transition: transform 0.3s;
 }
 .metadata-panel img:hover { transform: scale(1.5); }
+#lyrics-button {
+  background: none;
+  border: none;
+  color: #fff;
+  padding: 0;
+  cursor: pointer;
+}
 #now-playing {
   flex-grow: 1;
   text-align: center;

--- a/app/templates/files.html
+++ b/app/templates/files.html
@@ -17,7 +17,6 @@
         {# <img src="/static/logo-header.png" alt="STREAMusic" class="navbar-title-img"> #}
       </div>
       <div class="navbar-right nav-actions">
-        <button id="toggleQueue" class="btn">Queue</button>
         <div class="hamburger-menu-wrapper">
           <div class="hamburger-menu" id="hamburger-menu" onclick="toggleHamburgerMenu()">
             <div></div>
@@ -92,7 +91,7 @@
   <div id="media-player-container">
       <div class="metadata-panel">
         <img id="album-artwork" src="" alt="Album Artwork">
-        <button id="lyrics-button" class="btn" onclick="openLyrics()">Lyrics</button>
+        <button id="lyrics-button" onclick="openLyrics()">Lyrics</button>
       </div>
     <div id="now-playing">
       <div id="now-playing-title" class="np-title"></div>
@@ -113,6 +112,7 @@
       <input type="range" id="volume-slider" min="0" max="100" step="1" value="50">
       <button class="btn" id="shuffleBtn" onclick="toggleShuffle()"><i class="fas fa-random"></i></button>
       <button class="btn" id="repeatBtn" onclick="toggleRepeat()"><i class="fas fa-redo"></i></button>
+      <button class="btn" id="toggleQueue">Q</button>
     </div>
   </div>
   


### PR DESCRIPTION
## Summary
- remove queue button from nav bar
- add queue toggle button to player controls
- restyle lyrics button to simple text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e79021b88332b9b60071b601dfb0