### PR TITLE
Adjust queue and lyrics buttons

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -436,6 +436,15 @@ main.queue-active { margin-right: 250px; }
   transition: transform 0.3s;
 }
 .metadata-panel img:hover { transform: scale(1.5); }
+#lyrics-button {
+  background: none;
+  border: none;
+  color: #fff;
+  padding: 0;
+  cursor: pointer;
+  font-family: 'Roboto', 'Montserrat', sans-serif;
+  margin-left: 6px;
+}
 #now-playing {
   flex-grow: 1;
   text-align: center;
@@ -478,6 +487,15 @@ main.queue-active { margin-right: 250px; }
   background-color: #1db954;
 }
 #shuffleBtn i, #repeatBtn i { color: #fff !important; }
+#toggleQueue {
+  background-color: transparent;
+  margin-left: 12px;
+  border-radius: 50%;
+  width: 36px; height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 #progress-bar {
   width: 120px;
   height: 6px;

--- a/app/templates/files.html
+++ b/app/templates/files.html
@@ -17,7 +17,6 @@
         {# <img src="/static/logo-header.png" alt="STREAMusic" class="navbar-title-img"> #}
       </div>
       <div class="navbar-right nav-actions">
-        <button id="toggleQueue" class="btn">Queue</button>
         <div class="hamburger-menu-wrapper">
           <div class="hamburger-menu" id="hamburger-menu" onclick="toggleHamburgerMenu()">
             <div></div>
@@ -92,7 +91,7 @@
   <div id="media-player-container">
       <div class="metadata-panel">
         <img id="album-artwork" src="" alt="Album Artwork">
-        <button id="lyrics-button" class="btn" onclick="openLyrics()">Lyrics</button>
+        <button id="lyrics-button" onclick="openLyrics()">Lyrics</button>
       </div>
     <div id="now-playing">
       <div id="now-playing-title" class="np-title"></div>
@@ -113,6 +112,7 @@
       <input type="range" id="volume-slider" min="0" max="100" step="1" value="50">
       <button class="btn" id="shuffleBtn" onclick="toggleShuffle()"><i class="fas fa-random"></i></button>
       <button class="btn" id="repeatBtn" onclick="toggleRepeat()"><i class="fas fa-redo"></i></button>
+      <button class="btn" id="toggleQueue">Q</button>
     </div>
   </div>
   


### PR DESCRIPTION
## Summary
- move queue toggle next to repeat control
- restyle lyrics button to use Roboto font
- fine tune margins for lyrics and queue buttons

## Testing
- `pytest -q` *(fails: KeyError: 'FLASK_SECRET_KEY')*

------
https://chatgpt.com/codex/tasks/task_e_6849e79021b88332b9b60071b601dfb0