### PR TITLE
Adjust album art and lyrics button styles

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -428,14 +428,14 @@ main.queue-active { margin-right: 250px; }
   display: flex;
   align-items: center;
   gap: 10px;
+  height: 100%;
 }
+/* Album artwork fills the player bar height without zoom on hover */
 .metadata-panel img {
-  width: 50px;
-  height: 50px;
+  height: 100%;
+  aspect-ratio: 1 / 1;
   border-radius: 5px;
-  transition: transform 0.3s;
 }
-.metadata-panel img:hover { transform: scale(1.5); }
 #lyrics-button {
   background: none;
   border: none;
@@ -443,6 +443,7 @@ main.queue-active { margin-right: 250px; }
   padding: 0;
   cursor: pointer;
   font-family: 'Roboto', 'Montserrat', sans-serif;
+  font-weight: bold;
   margin-left: 6px;
 }
 #now-playing {
@@ -642,7 +643,7 @@ main.queue-active { margin-right: 250px; }
   .queue-btn.btn { font-size: 0.76rem; padding: 3px 6px; }
   .files-section { padding: 8px 1vw 120px 1vw; }
   #media-player-container { font-size: 0.93rem; }
-  .metadata-panel img { width: 35px; height: 35px; }
+  .metadata-panel img { height: 100%; aspect-ratio: 1 / 1; }
 }
 
 /* ========== UTILITY ========== */


### PR DESCRIPTION
## Summary
- resize album artwork to fill the media player bar
- remove hover zoom effect on the album art
- bolden the "Lyrics" button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6851626d57c48332b9a55dd52bfa8af0