### PR TITLE
Add stream and metadata route tests

### DIFF
--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -1,6 +1,14 @@
-import pytest 
-import sys, os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import pytest
+import sys
+import os
+
+# ensure required environment variables so the app can be created
+os.environ.setdefault("FLASK_SECRET_KEY", "testing-secret")
+os.environ.setdefault("CLIENT_ID", "dummy-client")
+os.environ.setdefault("CLIENT_SECRET", "dummy-secret")
+os.environ.setdefault("REDIRECT_URI", "http://localhost/callback")
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from streamusic import app as flask_app
 print("✅ TEST using app from:", flask_app.import_name)
@@ -31,3 +39,63 @@ def test_get_files_redirects_when_logged_out(client):
     print("🧪 REDIRECT TO:", response.headers.get("Location"))
     assert response.status_code == 302
     assert "/login" in response.headers["Location"] or "login" in response.headers["Location"].lower()
+
+
+def test_stream_endpoint_returns_audio(monkeypatch, client):
+    """Stream endpoint should proxy audio with correct headers."""
+
+    # mock authentication header
+    monkeypatch.setattr("app.main.routes.get_auth_headers", lambda: {"Authorization": "Bearer token"})
+
+    class DummyResponse:
+        status_code = 200
+        headers = {
+            "Content-Type": "audio/mpeg",
+            "Content-Length": "100",
+        }
+
+        def iter_content(self, chunk_size=1):
+            yield b"data"
+
+    monkeypatch.setattr("app.main.routes.http.get", lambda url, headers=None, stream=None: DummyResponse())
+
+    resp = client.get("/stream/fid")
+
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"] == "audio/mpeg"
+    assert resp.headers["Content-Length"] == "100"
+
+
+def test_metadata_endpoint_returns_expected_fields(monkeypatch, client):
+    """Metadata endpoint should return title, artist, album, duration and album_art."""
+
+    monkeypatch.setattr("app.main.routes.get_auth_headers", lambda: {"Authorization": "Bearer token"})
+
+    class DummyHttpResponse:
+        status_code = 200
+        content = b"mp3data"
+
+    monkeypatch.setattr("app.main.routes.http_metadata.get", lambda *a, **kw: DummyHttpResponse())
+
+    class DummyMP3:
+        def __init__(self, _io):
+            self.info = type("Info", (), {"length": 123})()
+            self.tags = {
+                "TIT2": type("T", (), {"text": ["Test Title"]})(),
+                "TPE1": type("T", (), {"text": ["Test Artist"]})(),
+                "TALB": type("T", (), {"text": ["Test Album"]})(),
+            }
+
+    monkeypatch.setattr("app.main.routes.MP3", DummyMP3)
+
+    resp = client.get("/metadata/fid")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        "title": "Test Title",
+        "artist": "Test Artist",
+        "album": "Test Album",
+        "duration": 123,
+        "album_art": "",
+    }


### PR DESCRIPTION
## Summary
- update test file to set required env vars
- add tests for the `/stream/<file_id>` and `/metadata/<file_id>` endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685166c0952c833293a7902030d4d2be