### PR TITLE
Fix session expiry redirect

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -105,6 +105,9 @@ function initEventListeners() {
       if (volumeSlider) volumeSlider.value = Math.round(audioPlayer.volume * 100);
       updateVolCSS();
     });
+    audioPlayer.addEventListener("error", () => {
+      window.location.href = "/login";
+    });
   }
 
   // --- Player Controls ---
@@ -366,7 +369,7 @@ function formatDuration(seconds) {
 
 function checkAuthResponse(response) {
   if (response.status === 401) {
-    window.location.href = "/";
+    window.location.href = "/login";
     throw new Error("InvalidAuthenticationToken");
   }
   return response;


### PR DESCRIPTION
## Summary
- handle audio playback errors by sending users to /login
- redirect fetch-based auth checks to login

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6889e01334708332903d61f831c183d8